### PR TITLE
eta implemented

### DIFF
--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -459,38 +459,42 @@ class LocalPlanner(rclpy.node.Node):
                 self.cur_pose.position.x, self.cur_pose.position.y
             )
 
-            # distance_remaining = self.calc_trip_dist(self.local_points, current_node)
+            # self.log("x: " + str(self.cur_pose.position.x) + "y: " + str(self.cur_pose.position.y))
+
+            distance_remaining = self.calc_trip_dist(self.local_points, current_node)
+
 
             # # Remaining time in seconds
-            # remaining_time = distance_remaining / self.cur_speed
+            remaining_time = distance_remaining / self.cur_speed
             eta_msg = UInt64()
 
             # # Calculate the ETA to the end
             # arrival_time = time.time() + remaining_time
 
             # # Convert the time to milliseconds
-            # eta_msg.data = int(arrival_time * (1000))
-            eta_msg.data = 0
+            eta_msg.data = int(remaining_time) # changed from arrival_time
+            # eta_msg.data = 0
             self.eta_pub.publish(eta_msg)
 
     def calc_trip_dist(self, points_list, start):
-        """Calculates the trip distance from the "start" index to the end of the "points_list"
+        """Calculates the trip distance from the "start" Point to the end of the "points_list"
 
         Args:
             points_list(List): The list of path points to calculate the distance of
-            start(int): The index of which to start calculating the trip distance
+            start(Point): The Point of which to start calculating the trip distance
         """
-        sum = 0
-        for i in range(start, len(points_list) - 1):
-            sum += self.calc_dist(
+        total_distance = 0
+
+        for i in range(self.local_points.index(start), len(points_list)):
+            total_distance += self.calc_dist(
                 points_list[i].x,
                 points_list[i].y,
-                points_list[i + 1].x,
-                points_list[i + 1].y,
+                points_list[i - 1].x,
+                points_list[i - 1].y,
             )
-            prev_node = i
-
-        return sum
+            # prev_node = i
+        # self.log(f"Distance remaining: {total_distance}")
+        return total_distance
 
     def get_closest_point(self, pos_x, pos_y):
         """Get the closest point along the raw path from pos_x, pos_y
@@ -499,15 +503,16 @@ class LocalPlanner(rclpy.node.Node):
             pos_x(float): The x position of search center
             pos_y(float): The y position of search center
         """
-        min_node = 0
+        min_node = None
         min_dist = float("inf")
-        for i in range(len(self.local_points)):
-            dist = self.calc_dist(
-                pos_x, pos_y, self.local_points[i].x, self.local_points[i].y
-            )
+        for point in self.local_points:
+            dist = self.calc_dist(pos_x, pos_y, point.x, point.y)
             if dist < min_dist:
                 min_dist = dist
-                min_node = i
+                min_node = point
+        
+        # self.log(f"Closest point to x: {pos_x}, y: {pos_y} is x: {min_node.x}, y: {min_node.y}")
+        return min_node
 
     def calc_dist(self, x1, y1, x2, y2):
         return math.sqrt(((x2 - x1) ** 2) + ((y2 - y1) ** 2))


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #84 and #82 

---

# Summary

Implements eta functionality 

---

# Testing Summary

Branches that impact cart functionality must be live tested on the
cart before submission unless explicitly exempted.

*exempted from live testing*

The navigation simulation is launched to start. Then in a separate browser, the eta topic is echoed. Then a point is selected and published in the simulation, and the eta data published is compared to the location of the cart. The data seems fairly reliable, but on start, sometimes a weirdly high eta is published. This is because the cart's current speed is used in eta calculation, and the first calculation is done while the cart is still picking up speed, throwing off the calculations. Eta can also increase if the cart diverges from the path, but that seems to be an issue in the cart navigating in the sim, rather than with the eta calculation.


---

# Testing Instructions

Reviewers are typically not required to live test on the cart.

Open two terminals
In the first terminal run: ros2 launch navigation sim nav.launch.py
In the second terminal run: ros2 topic echo eta
Put the terminal with eta being echoed and rviz on the screen at the same time.
Publish a new point in rviz and compare the distance left to eta data being published.


If the cart starts circling, start a new instance of rviz. It's not required to restart the topic echo in this case.


---

# Success Metrics (From Issue)

- [ ] Metric 1: Eta is calculated and matches the cart arrival.

---

# Integration Impact

Does this change affect other subsystems? If yes, explain the interaction.

Other subsystems are not currently affected. In the future, this data will be sent to anomaly detection and potentially the frontend.


