### PR TITLE
made the coordinate transformation in main

### DIFF
--- a/navigation/navigation/lidar_object_to_obstacle.py
+++ b/navigation/navigation/lidar_object_to_obstacle.py
@@ -148,8 +148,10 @@ class LidarObjectToObstacle(rclpy.node.Node):
     """
     def get_point(self, angle, distance):
 
-        x = math.sin(angle) * distance
-        y = math.cos(angle) * distance
+        # LaserScan polar->Cartesian in ROS convention:
+        # x forward, y left, angle measured from +x toward +y.
+        x = math.cos(angle) * distance
+        y = math.sin(angle) * distance
 
         return x, y
 


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #122 

---

# Summary

Fixes incorrect polar to Cartesian conversion in obstacle processing. This corrects rotated obstacle positions.
---

# Testing Summary

Testing process: Visualized data in RViz with known obstacle placement before and after the fix

Observed results: Points now align correctly with expected positions

Edge cases explored: Objects directly ahead, to the side, and at angles

---

# Testing Instructions

- Launch the system
- Open RViz
- Visualize LiDAR/obstacle data
- Place objects in front and to the side of the robot

---

# Success Metrics (From Issue)

-  Metric 1: Point cloud correctly aligned with robot frame
-  Metric 2: Obstacle positions match expected locations within small error
-  Metric 3: No navigation issues caused by misaligned obstacles

---

# Integration Impact

Yes. This change affects anything using obstacle data and may impact navigation.



