### PR TITLE
changes remappings for topics to work

### DIFF
--- a/navigation/launch/pointcloud-to-laserscan.launch.py
+++ b/navigation/launch/pointcloud-to-laserscan.launch.py
@@ -28,8 +28,8 @@ def generate_launch_description():
         ),
         Node(
             package='pointcloud_to_laserscan', executable='pointcloud_to_laserscan_node',
-            remappings=[('cloud_in', [LaunchConfiguration(variable_name='scanner'), '/cloud']),
-                        ('scan', [LaunchConfiguration(variable_name='scanner'), '/scan'])],
+            remappings=[('cloud_in', '/cloud_in'),
+                        ('scan', '/scanner/scan')],
             parameters=[{
                 'min_height': -1.0,
                 'max_height': 0.0,


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #124 

---

# Summary

This fixes topic remappings for the pointcloud to laserscan node. Removes dynamic launch-based topic construction and replaces it with fixed topic names for consistency.
---

# Testing Summary

Testing process: Launched system and verified topic outputs using ROS tools
Observed results: Node publishes and subscribes using the updated fixed topics without errors

---

# Testing Instructions

Launch the system
Check active topics:
-  ros2 topic list

Verify:
- Input topic: /cloud_in
- Output topic: /scanner/scan

Echo scan output:
- ros2 topic echo /scanner/scan

Expected:
- Node receives point cloud data on /cloud_in
- Laser scan data is published on /scanner/scan

---

# Success Metrics (From Issue)

 Metric 1: Node subscribes to correct input topic
 Metric 2: LaserScan output is published consistently

---

# Integration Impact

Yes. This changes topic names, so any components subscribing to the old scan topic or publishing to the old cloud topic will need to be updated.