### PR TITLE
visualization changes rviz

### DIFF
--- a/cart_control/cart_launch/rviz/localization.rviz
+++ b/cart_control/cart_launch/rviz/localization.rviz
@@ -230,6 +230,30 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /graph_visual
       Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: CollisionBoundaries
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 100
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /boundaries_array
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: CollisionCandidates
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 100
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /collision_pub
+      Value: true
     - Class: rviz_default_plugins/Image
       Enabled: true
       Max Value: 1

--- a/navigation/navigation/collision_detector.py
+++ b/navigation/navigation/collision_detector.py
@@ -493,21 +493,34 @@ class CollisionDetector(rclpy.node.Node):
         bound_display.lifetime = Duration(seconds=0.033).to_msg()
         bound_display.type = Marker.LINE_STRIP
         bound_display.header.frame_id = "/base_link"
-        bound_display.scale.x = 0.2
+        bound_display.scale.x = 0.05
         bound_display.color.r = 1.0
         bound_display.color.g = 1.0
         bound_display.color.b = 0.0
         bound_display.color.a = 1.0
         bound_display.action = Marker.ADD
 
-        # Obtain the angle range necessary for a certain arc length in this case 20
-        ang = 20 / (2 * radius)
+        # Build a fixed arc length (meters) and sample with a minimum number of points so
+        # the curve remains visible in RViz even when steering is near straight.
+        arc_length_m = 5.0
+        radius_abs = abs(radius)
+        if radius_abs < 1e-6:
+            return bound_display
 
-        # Setup arc display range
+        # Central angle swept by the requested arc length.
+        ang = arc_length_m / radius_abs
+
+        # Setup arc display range.
         if right_turn:
-            loop_range = np.arange((math.pi / 2) + ang, math.pi / 2, 0.10)
+            start_ang = (math.pi / 2) - ang
+            end_ang = math.pi / 2
         else:
-            loop_range = np.arange(-(math.pi / 2), (-(math.pi / 2)) + ang, 0.10)
+            start_ang = -(math.pi / 2)
+            end_ang = (-(math.pi / 2)) + ang
+
+        # Use linspace so we always get points, regardless of turn direction and angular span.
+        point_count = max(30, int(abs(end_ang - start_ang) / 0.02))
+        loop_range = np.linspace(start_ang, end_ang, point_count)
 
         # Obtain the points along the arc on the circle
         for ang in loop_range:


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #98 

---

# Summary

Updates collision visualization and arc rendering for clearer RViz output. Adds marker displays for collision boundaries and collision candidates, and improves arc generation so curves remain visible and consistent across turn conditions.
---

# Testing Summary

Testing process: Ran the system in RViz and reviewed collision markers and arc displays during different steering conditions.

Observed results: Collision boundaries and candidate markers appear in RViz, and arc displays are smoother and easier to see.

Edge cases explored: Tested left turns, right turns, and very large radius cases.

---

# Testing Instructions

Launch the system
Open RViz
Verify these topics are visible:
- /boundaries_array
- /collision_pub
Check arc visualization during different steering commands

Expected:
- Collision boundaries display in RViz
- Arcs render smoothly and remain visible

---

# Success Metrics (From Issue)

List the concrete success metrics defined in the issue and explain how
they are satisfied.

 Metric 1: Collision boundary markers are visible in RViz
 Metric 2: Arc visualization remains clear and consistent across steering conditions

---

# Integration Impact

No



