### PR TITLE
Motor eta UI logging

### DIFF
--- a/cart_control/cart_launch/config/cart_madison.yaml
+++ b/cart_control/cart_launch/config/cart_madison.yaml
@@ -1,2 +1,2 @@
-zed_front_serial: 37963597
-zed_rear_serial: 31061594
+zed_front_serial: 38667373
+zed_rear_serial: 34733362

--- a/cart_control/cart_launch/launch/autonomous_launcher.launch.py
+++ b/cart_control/cart_launch/launch/autonomous_launcher.launch.py
@@ -28,6 +28,11 @@ def generate_launch_description():
         ),
         description="Path to cart-specific YAML config (must contain zed_front_serial and zed_rear_serial)",
     )
+    declare_enable_aad = DeclareLaunchArgument(
+        "enable_aad",
+        default_value="true",
+        description="Enable anomaly logging",
+    )
 
     swri_console_node = Node(
         package="swri_console",
@@ -53,14 +58,20 @@ def generate_launch_description():
     navigation_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [FindPackageShare("navigation"), "/launch/navigation.launch.py"]
-        )
+        ),
+        launch_arguments={
+            "enable_aad": LaunchConfiguration("enable_aad"),
+        }.items(),
     )
 
     # Launch the motor control launcher
     motor_control_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [FindPackageShare("motor_control"), "/launch/motor.launch.py"]
-        )
+        ),
+        launch_arguments={
+            "enable_aad": LaunchConfiguration("enable_aad"),
+        }.items(),
     )
 
     # Execute the RViz2 command with the specified configuration file
@@ -100,6 +111,7 @@ def generate_launch_description():
         [
             declare_console_start_delay_s,
             declare_cart_config_path,
+            declare_enable_aad,
             swri_console_node,
             delayed_stack,
         ]

--- a/motor_control/launch/motor.launch.py
+++ b/motor_control/launch/motor.launch.py
@@ -12,6 +12,11 @@ def generate_launch_description():
         [
             DeclareLaunchArgument("baudrate", default_value="57600"),
             DeclareLaunchArgument("arduino_port", default_value="/dev/ttyUSB0"),
+            DeclareLaunchArgument(
+                "enable_aad",
+                default_value="true",
+                description="Enable anomaly logging node"
+            ),
             Node(
                 package="motor_control",
                 executable="motor_endpoint",
@@ -20,6 +25,7 @@ def generate_launch_description():
                     {
                         "baudrate": LaunchConfiguration("baudrate"),
                         "arduino_port": LaunchConfiguration("arduino_port"),
+                        "enable_aad": LaunchConfiguration("enable_aad")
                     }
                 ],
             ),

--- a/motor_control/motor_control/motor_endpoint.py
+++ b/motor_control/motor_control/motor_endpoint.py
@@ -43,7 +43,14 @@ class MotorEndpoint(rclpy.node.Node):
         self.STEERING_TOLERANCE = 50
         self.COMFORT_STOP_DIST = 4.0
         self.STEERING_CORRECTION = 10
-        self.AAD_LOGGING_ENABLED = True
+        
+        self.declare_parameter("enable_aad", True)
+
+        self.AAD_LOGGING_ENABLED = (
+            self.get_parameter("enable_aad")
+            .get_parameter_value()
+            .bool_value
+        )
 
         # Driving vars
         self.state = STOPPED

--- a/motor_control/motor_control/motor_endpoint.py
+++ b/motor_control/motor_control/motor_endpoint.py
@@ -18,11 +18,17 @@ from motor_control_interface.msg import VelAngle
 from std_msgs.msg import Bool, String
 from geometry_msgs.msg import TwistStamped
 
+# Annolmaly Logging based imports
+from std_msgs.msg import Float32 
+from anomaly_msg.msg import AnomalyMsg 
+import struct
 
 # State constants
 MOVING = 0
 BRAKING = 1
 STOPPED = 2
+
+AAD_LOGGING_ENABLED = True
 
 
 class MotorEndpoint(rclpy.node.Node):
@@ -76,9 +82,16 @@ class MotorEndpoint(rclpy.node.Node):
             time.sleep(2)
             self.serial_connected = True
             self.log_header("CONNECTED TO ARDUINO")
+            
+            if AAD_LOGGING_ENABLED: #Anomamly Logging
+                self.log_aad(AnomalyMsg.INFO, "CONNECTED TO ARDUINO")
+                
         except Exception as e:
             self.log_header("MOTOR ENDPOINT: " + str(e))
             self.serial_connected = False
+            
+            if AAD_LOGGING_ENABLED: #Anomamly Logging
+                self.log_aad(AnomalyMsg.ERROR, "MOTOR ENDPOINT: " + str(e))
 
         # ROS2 SUBSCRIBERS
 
@@ -99,6 +112,13 @@ class MotorEndpoint(rclpy.node.Node):
 
         # heartbeat is used to ensure that we have a stable connection with the ardiuno
         self.heart_pub = self.create_publisher(String, "/heartbeat", 10)
+
+        # Sets up publishing to /ai_anomaly_logging
+        if AAD_LOGGING_ENABLED:
+            self.aad_pub = self.create_publisher(
+                AnomalyMsg,
+                "/ai_anomaly_logging",
+                10)
 
         # ROS2 TIMERS
         self.timer = self.create_timer(1.0 / self.NODE_RATE, self.timer_callback)
@@ -166,6 +186,10 @@ class MotorEndpoint(rclpy.node.Node):
             self.serial_connected = True
         except Exception as e:
             self.log_header("MOTOR ENDPOINT: " + str(e))
+
+            if AAD_LOGGING_ENABLED: #Anomamly Logging
+                self.log_aad(AnomalyMsg.ERROR, "MOTOR ENDPOINT: " + str(e))   
+            
             self.serial_connected = False
             
     def timer_callback(self):
@@ -195,6 +219,9 @@ class MotorEndpoint(rclpy.node.Node):
             self.heartbeat = self.arduino_ser.read_until()
         except Exception as e:
             self.log_header("THE ARDUINO HAS BEEN DISCONNECTED")
+            
+            if AAD_LOGGING_ENABLED: #Anomamly Logging
+                self.log_aad(AnomalyMsg.ERROR, "THE ARDUINO HAS BEEN DISCONNECTED")       
 
             # Same thing as above. if the ardiuno had some problems... ie: it disconnected attempt to retry the connection.
             # Return to end the current instance of the time callback we are in if it fails to connect.
@@ -213,6 +240,10 @@ class MotorEndpoint(rclpy.node.Node):
             # This is because of the rest of the setup taking place at the same time
             if heartbeat_delta_t >= 2.0:
                 self.log_header("TIME BETWEEN HEARTBEATS, > 2.0s | Things may be fine")
+                
+                if AAD_LOGGING_ENABLED: #Anomamly Logging
+                    self.log_aad(AnomalyMsg.WARNING, "TIME BETWEEN HEARTBEATS, > 2.0s | Things may be fine")
+                    
         self.prev_time = cur_time
         return
 
@@ -237,6 +268,9 @@ class MotorEndpoint(rclpy.node.Node):
                 self.vel_cart_units = -254
             if self.vel_cart_units < 0:
                 self.log_header("NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
+                
+                if AAD_LOGGING_ENABLED: #Anomamly Logging
+                    self.log_aad(AnomalyMsg.ERROR, "NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
 
         target_speed = int(self.vel_cart_units)  # float64
 
@@ -310,7 +344,10 @@ class MotorEndpoint(rclpy.node.Node):
                 self.vel_curr_cart_units = 254
             if self.vel_cart_units < 0:
                 self.log_header("NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
-
+                
+                if AAD_LOGGING_ENABLED: #Anomamly Logging
+                    self.log_aad(AnomalyMsg.ERROR, "NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
+                    
         target_speed = int(self.vel_cart_units)  # float64
 
         # Adjust the target_angle range from (-45 <-> 45) to (0 <-> 100)
@@ -403,6 +440,23 @@ class MotorEndpoint(rclpy.node.Node):
         """Helper method to print  log tatements."""
         self.get_logger().info(f"{msg}")
 
+    # This is for publishing to anolmamly logging
+    def log_aad(self, importance: int, motor_endpoint_msg: str):
+        anomaly = AnomalyMsg() 
+        
+        # Header 
+        anomaly.header.stamp = self.get_clock().now().to_msg() 
+        anomaly.header.frame_id = "motor_endpoint_frame" 
+        
+        # Required fields 
+        anomaly.node_name = self.get_name() 
+        anomaly.importance = importance
+        anomaly.type = AnomalyMsg.TEXT 
+        
+        # Human-readable message 
+        anomaly.msg = f"Received Motor Endpoint Info: {motor_endpoint_msg}" 
+        #Publish 
+        self.anomaly_pub.publish(anomaly) 
 
 def main():
     """The main method that actually handles spinning up the node."""

--- a/motor_control/motor_control/motor_endpoint.py
+++ b/motor_control/motor_control/motor_endpoint.py
@@ -17,6 +17,7 @@ import rclpy
 from motor_control_interface.msg import VelAngle
 from std_msgs.msg import Bool, String
 from geometry_msgs.msg import TwistStamped
+from std_msgs.msg import Header
 
 # Annolmaly Logging based imports
 from std_msgs.msg import Float32 
@@ -74,6 +75,14 @@ class MotorEndpoint(rclpy.node.Node):
             self.get_parameter("manual_control").get_parameter_value().bool_value
         )  # Sets the cart to use teleop control logic instead of autonomous control
 
+
+        # Sets up publishing to /ai_anomaly_logging
+        if AAD_LOGGING_ENABLED:
+            self.aad_pub = self.create_publisher(
+                AnomalyMsg,
+                "/ai_anomaly_logging",
+                10)
+
         # Need to sleep after first connection to let serial establish
         try:
             self.arduino_ser = sr.Serial(
@@ -83,14 +92,14 @@ class MotorEndpoint(rclpy.node.Node):
             self.serial_connected = True
             self.log_header("CONNECTED TO ARDUINO")
             
-            if AAD_LOGGING_ENABLED: #Anomamly Logging
+            if AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.INFO, "CONNECTED TO ARDUINO")
                 
         except Exception as e:
             self.log_header("MOTOR ENDPOINT: " + str(e))
             self.serial_connected = False
             
-            if AAD_LOGGING_ENABLED: #Anomamly Logging
+            if AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.ERROR, "MOTOR ENDPOINT: " + str(e))
 
         # ROS2 SUBSCRIBERS
@@ -112,13 +121,6 @@ class MotorEndpoint(rclpy.node.Node):
 
         # heartbeat is used to ensure that we have a stable connection with the ardiuno
         self.heart_pub = self.create_publisher(String, "/heartbeat", 10)
-
-        # Sets up publishing to /ai_anomaly_logging
-        if AAD_LOGGING_ENABLED:
-            self.aad_pub = self.create_publisher(
-                AnomalyMsg,
-                "/ai_anomaly_logging",
-                10)
 
         # ROS2 TIMERS
         self.timer = self.create_timer(1.0 / self.NODE_RATE, self.timer_callback)
@@ -187,7 +189,7 @@ class MotorEndpoint(rclpy.node.Node):
         except Exception as e:
             self.log_header("MOTOR ENDPOINT: " + str(e))
 
-            if AAD_LOGGING_ENABLED: #Anomamly Logging
+            if AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.ERROR, "MOTOR ENDPOINT: " + str(e))   
             
             self.serial_connected = False
@@ -220,7 +222,7 @@ class MotorEndpoint(rclpy.node.Node):
         except Exception as e:
             self.log_header("THE ARDUINO HAS BEEN DISCONNECTED")
             
-            if AAD_LOGGING_ENABLED: #Anomamly Logging
+            if AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.ERROR, "THE ARDUINO HAS BEEN DISCONNECTED")       
 
             # Same thing as above. if the ardiuno had some problems... ie: it disconnected attempt to retry the connection.
@@ -241,7 +243,7 @@ class MotorEndpoint(rclpy.node.Node):
             if heartbeat_delta_t >= 2.0:
                 self.log_header("TIME BETWEEN HEARTBEATS, > 2.0s | Things may be fine")
                 
-                if AAD_LOGGING_ENABLED: #Anomamly Logging
+                if AAD_LOGGING_ENABLED: #Anomaly Logging
                     self.log_aad(AnomalyMsg.WARNING, "TIME BETWEEN HEARTBEATS, > 2.0s | Things may be fine")
                     
         self.prev_time = cur_time
@@ -269,7 +271,7 @@ class MotorEndpoint(rclpy.node.Node):
             if self.vel_cart_units < 0:
                 self.log_header("NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
                 
-                if AAD_LOGGING_ENABLED: #Anomamly Logging
+                if AAD_LOGGING_ENABLED: #Anomaly Logging
                     self.log_aad(AnomalyMsg.ERROR, "NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
 
         target_speed = int(self.vel_cart_units)  # float64
@@ -345,7 +347,7 @@ class MotorEndpoint(rclpy.node.Node):
             if self.vel_cart_units < 0:
                 self.log_header("NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
                 
-                if AAD_LOGGING_ENABLED: #Anomamly Logging
+                if AAD_LOGGING_ENABLED: #Anomaly Logging
                     self.log_aad(AnomalyMsg.ERROR, "NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
                     
         target_speed = int(self.vel_cart_units)  # float64
@@ -440,11 +442,12 @@ class MotorEndpoint(rclpy.node.Node):
         """Helper method to print  log tatements."""
         self.get_logger().info(f"{msg}")
 
-    # This is for publishing to anolmamly logging
+    # This is for publishing to anomaly logging
     def log_aad(self, importance: int, motor_endpoint_msg: str):
         anomaly = AnomalyMsg() 
         
         # Header 
+        anomaly.header = Header()
         anomaly.header.stamp = self.get_clock().now().to_msg() 
         anomaly.header.frame_id = "motor_endpoint_frame" 
         
@@ -456,7 +459,7 @@ class MotorEndpoint(rclpy.node.Node):
         # Human-readable message 
         anomaly.msg = f"Received Motor Endpoint Info: {motor_endpoint_msg}" 
         #Publish 
-        self.anomaly_pub.publish(anomaly) 
+        self.aad_pub.publish(anomaly) 
 
 def main():
     """The main method that actually handles spinning up the node."""

--- a/motor_control/motor_control/motor_endpoint.py
+++ b/motor_control/motor_control/motor_endpoint.py
@@ -29,7 +29,6 @@ MOVING = 0
 BRAKING = 1
 STOPPED = 2
 
-AAD_LOGGING_ENABLED = True
 
 
 class MotorEndpoint(rclpy.node.Node):
@@ -44,6 +43,7 @@ class MotorEndpoint(rclpy.node.Node):
         self.STEERING_TOLERANCE = 50
         self.COMFORT_STOP_DIST = 4.0
         self.STEERING_CORRECTION = 10
+        self.AAD_LOGGING_ENABLED = True
 
         # Driving vars
         self.state = STOPPED
@@ -77,7 +77,7 @@ class MotorEndpoint(rclpy.node.Node):
 
 
         # Sets up publishing to /ai_anomaly_logging
-        if AAD_LOGGING_ENABLED:
+        if self.AAD_LOGGING_ENABLED:
             self.aad_pub = self.create_publisher(
                 AnomalyMsg,
                 "/ai_anomaly_logging",
@@ -91,15 +91,16 @@ class MotorEndpoint(rclpy.node.Node):
             time.sleep(2)
             self.serial_connected = True
             self.log_header("CONNECTED TO ARDUINO")
-            
-            if AAD_LOGGING_ENABLED: #Anomaly Logging
+
+            if self.AAD_LOGGING_ENABLED: #Anomaly Logging
+                
                 self.log_aad(AnomalyMsg.INFO, "CONNECTED TO ARDUINO")
                 
         except Exception as e:
             self.log_header("MOTOR ENDPOINT: " + str(e))
             self.serial_connected = False
             
-            if AAD_LOGGING_ENABLED: #Anomaly Logging
+            if self.AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.ERROR, "MOTOR ENDPOINT: " + str(e))
 
         # ROS2 SUBSCRIBERS
@@ -189,7 +190,7 @@ class MotorEndpoint(rclpy.node.Node):
         except Exception as e:
             self.log_header("MOTOR ENDPOINT: " + str(e))
 
-            if AAD_LOGGING_ENABLED: #Anomaly Logging
+            if self.AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.ERROR, "MOTOR ENDPOINT: " + str(e))   
             
             self.serial_connected = False
@@ -222,7 +223,7 @@ class MotorEndpoint(rclpy.node.Node):
         except Exception as e:
             self.log_header("THE ARDUINO HAS BEEN DISCONNECTED")
             
-            if AAD_LOGGING_ENABLED: #Anomaly Logging
+            if self.AAD_LOGGING_ENABLED: #Anomaly Logging
                 self.log_aad(AnomalyMsg.ERROR, "THE ARDUINO HAS BEEN DISCONNECTED")       
 
             # Same thing as above. if the ardiuno had some problems... ie: it disconnected attempt to retry the connection.
@@ -240,10 +241,11 @@ class MotorEndpoint(rclpy.node.Node):
 
             # This check is here because the time between the first and 2nd heartbeat is always ~2.4s
             # This is because of the rest of the setup taking place at the same time
+  
             if heartbeat_delta_t >= 2.0:
                 self.log_header("TIME BETWEEN HEARTBEATS, > 2.0s | Things may be fine")
                 
-                if AAD_LOGGING_ENABLED: #Anomaly Logging
+                if self.AAD_LOGGING_ENABLED: #Anomaly Logging
                     self.log_aad(AnomalyMsg.WARNING, "TIME BETWEEN HEARTBEATS, > 2.0s | Things may be fine")
                     
         self.prev_time = cur_time
@@ -271,7 +273,7 @@ class MotorEndpoint(rclpy.node.Node):
             if self.vel_cart_units < 0:
                 self.log_header("NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
                 
-                if AAD_LOGGING_ENABLED: #Anomaly Logging
+                if self.AAD_LOGGING_ENABLED: #Anomaly Logging
                     self.log_aad(AnomalyMsg.ERROR, "NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
 
         target_speed = int(self.vel_cart_units)  # float64
@@ -347,7 +349,7 @@ class MotorEndpoint(rclpy.node.Node):
             if self.vel_cart_units < 0:
                 self.log_header("NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
                 
-                if AAD_LOGGING_ENABLED: #Anomaly Logging
+                if self.AAD_LOGGING_ENABLED: #Anomaly Logging
                     self.log_aad(AnomalyMsg.ERROR, "NEGATIVE VELOCITY REQUESTED FOR THE MOTOR ENDPOINT!")
                     
         target_speed = int(self.vel_cart_units)  # float64
@@ -444,6 +446,8 @@ class MotorEndpoint(rclpy.node.Node):
 
     # This is for publishing to anomaly logging
     def log_aad(self, importance: int, motor_endpoint_msg: str):
+
+
         anomaly = AnomalyMsg() 
         
         # Header 

--- a/navigation/launch/navigation.launch.py
+++ b/navigation/launch/navigation.launch.py
@@ -77,7 +77,7 @@ def generate_launch_description():
             Node(
                 package="navigation",
                 executable="collision_avoidance_aad_log",
-                name="collision_avoidance_anomaly_log",
+                name="collision_avoidance_aad_log",
                 output="screen",
                 condition=IfCondition(LaunchConfiguration("enable_aad")),
             ),

--- a/navigation/launch/navigation.launch.py
+++ b/navigation/launch/navigation.launch.py
@@ -6,6 +6,7 @@ from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.conditions import IfCondition
 from launch.actions import IncludeLaunchDescription
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory 
@@ -20,6 +21,11 @@ def generate_launch_description():
                 default_value=os.path.join(
                     get_package_share_directory("navigation"), "maps", "main_shift3.gml"
                 ),
+            ),
+            DeclareLaunchArgument(
+                "enable_aad",
+                default_value="true",
+                description="Enable collision avoidance anomaly logging node"
             ),
             Node(
                 package="navigation",
@@ -67,6 +73,13 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource(
                     [FindPackageShare("navigation"), "/launch/pointcloud-to-laserscan.launch.py"]
                 )
+            ),
+            Node(
+                package="navigation",
+                executable="collision_avoidance_aad_log",
+                name="collision_avoidance_anomaly_log",
+                output="screen",
+                condition=IfCondition(LaunchConfiguration("enable_aad")),
             ),
         ]
     )

--- a/navigation/navigation/collision_avoidance_aad_log.py
+++ b/navigation/navigation/collision_avoidance_aad_log.py
@@ -1,11 +1,14 @@
 import rclpy
 from rclpy.node import Node
+from rclpy.executors import MultiThreadedExecutor
+import threading
+from queue import Queue
 
 from sensor_msgs.msg import Image
 from std_msgs.msg import Float32
 from navigation_interface.msg import Stop
 from std_msgs.msg import Header
-from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, qos_profile_sensor_data
 
 from anomaly_msg.msg import AnomalyMsg
 
@@ -15,21 +18,28 @@ class CollisionAvoidanceAADLog(Node):
     def __init__(self):
         super().__init__('collision_avoidance_aad_log')
 
-        self.IMG_PUBLISH_PERIOD = 0.5 
+        self.IMG_PUBLISH_PERIOD = 5
 
-        self.get_logger().info("Creating subsribers")
+        self.get_logger().info("Creating subscribers")
         # --- Subscribers ---
 
-
+        # Use minimal QoS for camera - drop frames if can't keep up
         camera_qos = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
             history=HistoryPolicy.KEEP_LAST,
-            depth=1
+            depth=1  # Only keep latest frame
         )
 
-        self.camera_sub = self.create_subscription(
+        self.camera_0_sub = self.create_subscription(
             Image,
             '/zed_front/zed_node_0/rgb/color/rect/image',
+            self.camera_callback,
+            camera_qos
+        )
+
+        self.camera_1_sub = self.create_subscription(
+            Image,
+            '/zed_rear/zed_node_1/rgb/color/rect/image',
             self.camera_callback,
             camera_qos
         )
@@ -47,36 +57,69 @@ class CollisionAvoidanceAADLog(Node):
             self.stop_callback,
             10
         )
-        self.get_logger().info("Finished creating subsribers")
+        self.get_logger().info("Finished creating subscribers")
         self.get_logger().info("Creating publishers")
 
         # --- Publisher ---
-        self.anomaly_pub = self.create_publisher(
+        self.anomaly_camera_pub = self.create_publisher(
+            AnomalyMsg,
+            '/ai_anomaly_logging',
+            camera_qos
+        )
+
+                # --- Publisher ---
+        self.anomaly_log_pub = self.create_publisher(
             AnomalyMsg,
             '/ai_anomaly_logging',
             10
         )
         self.get_logger().info("Finished creating publishers")
 
-        self.last_image = None
+        self.last_pub_time = self.get_clock().now()
         self.last_speed = 0.0
 
-        self.timer = self.create_timer(
-            self.IMG_PUBLISH_PERIOD, 
-            self.timer_callback)
+        # --- Async processing setup ---
+        self.image_queue = Queue(maxsize=1)  # Only keep latest image
+        self.processing_thread = threading.Thread(target=self._process_images, daemon=True)
+        self.processing_thread.start()
+
+    def _process_images(self):
+        """Background thread that processes images without blocking the callback"""
+        while rclpy.ok():
+            try:
+                # Block until an image is available
+                img_msg = self.image_queue.get(timeout=0.1)
+                
+                now = self.get_clock().now()
+                
+                # Only process if enough time has passed
+                if (now - self.last_pub_time).nanoseconds > self.IMG_PUBLISH_PERIOD * 1e9:
+                    # Create and publish anomaly with full image data
+                    anomaly = AnomalyMsg()
+                    anomaly.header = img_msg.header
+                    anomaly.node_name = self.get_name()
+                    anomaly.importance = AnomalyMsg.INFO
+                    anomaly.type = AnomalyMsg.IMAGE
+                    anomaly.msg = "Camera frame received."
+                    anomaly.image = img_msg  # Full image is safe here - no blocking
+
+                    self.anomaly_camera_pub.publish(anomaly)
+                    self.last_pub_time = now
+                    
+            except:
+                # Queue timeout - continue waiting
+                pass
 
     # --- Callbacks ---
 
     def camera_callback(self, img_msg: Image):
-        anomaly = AnomalyMsg()
-        anomaly.header = img_msg.header
-        anomaly.node_name = self.get_name()
-        anomaly.importance = AnomalyMsg.INFO
-        anomaly.type = AnomalyMsg.IMAGE
-        anomaly.msg = "Camera frame received."
-        anomaly.image = img_msg
-
-        self.last_image = anomaly
+        """Callback returns immediately - just queues the image"""
+        try:
+            # Non-blocking: put latest image, discard old one if queue full
+            self.image_queue.put_nowait(img_msg)
+        except:
+            # Queue full - that's okay, we'll process the next frame
+            pass
 
     def stop_callback(self, stop_msg: Stop):
         anomaly = AnomalyMsg()
@@ -88,7 +131,7 @@ class CollisionAvoidanceAADLog(Node):
             anomaly.importance = AnomalyMsg.WARNING
             anomaly.msg = "Stop signal received."
 
-            self.anomaly_pub.publish(anomaly)
+            self.anomaly_log_pub.publish(anomaly)
 
     def speed_callback(self, msg: Float32):
         if abs(self.last_speed - msg.data) > 0.1:
@@ -105,25 +148,22 @@ class CollisionAvoidanceAADLog(Node):
             anomaly.type = AnomalyMsg.TEXT
             anomaly.msg = f"The speed of the cart is {msg.data}"
 
-            self.anomaly_pub.publish(anomaly)
-
-    def timer_callback(self):
-        if self.last_image: 
-            self.get_logger().info("Publishing image")
-
-
-            self.anomaly_pub.publish(self.last_image)
-            self.last_image = None
-        else:
-            self.get_logger().info("Issue with previous image")
+            self.anomaly_log_pub.publish(anomaly)
     
 
 def main(args=None):
     rclpy.init(args=args)
     node = CollisionAvoidanceAADLog()
-    rclpy.spin(node)
-    node.destroy_node()
-    rclpy.shutdown()
+    
+    # Use MultiThreadedExecutor to allow background thread to work
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    
+    try:
+        executor.spin()
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/navigation/navigation/collision_avoidance_aad_log.py
+++ b/navigation/navigation/collision_avoidance_aad_log.py
@@ -1,0 +1,130 @@
+import rclpy
+from rclpy.node import Node
+
+from sensor_msgs.msg import Image
+from std_msgs.msg import Float32
+from navigation_interface.msg import Stop
+from std_msgs.msg import Header
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+
+from anomaly_msg.msg import AnomalyMsg
+
+
+class CollisionAvoidanceAADLog(Node):
+
+    def __init__(self):
+        super().__init__('collision_avoidance_aad_log')
+
+        self.IMG_PUBLISH_PERIOD = 0.5 
+
+        self.get_logger().info("Creating subsribers")
+        # --- Subscribers ---
+
+
+        camera_qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1
+        )
+
+        self.camera_sub = self.create_subscription(
+            Image,
+            '/zed_front/zed_node_0/rgb/color/rect/image',
+            self.camera_callback,
+            camera_qos
+        )
+
+        self.speed_sub = self.create_subscription(
+            Float32,
+            '/speed',
+            self.speed_callback,
+            10
+        )
+
+        self.stop_sub = self.create_subscription(
+            Stop,
+            '/stop',
+            self.stop_callback,
+            10
+        )
+        self.get_logger().info("Finished creating subsribers")
+        self.get_logger().info("Creating publishers")
+
+        # --- Publisher ---
+        self.anomaly_pub = self.create_publisher(
+            AnomalyMsg,
+            '/ai_anomaly_logging',
+            10
+        )
+        self.get_logger().info("Finished creating publishers")
+
+        self.last_image = None
+        self.last_speed = 0.0
+
+        self.timer = self.create_timer(
+            self.IMG_PUBLISH_PERIOD, 
+            self.timer_callback)
+
+    # --- Callbacks ---
+
+    def camera_callback(self, img_msg: Image):
+        anomaly = AnomalyMsg()
+        anomaly.header = img_msg.header
+        anomaly.node_name = self.get_name()
+        anomaly.importance = AnomalyMsg.INFO
+        anomaly.type = AnomalyMsg.IMAGE
+        anomaly.msg = "Camera frame received."
+        anomaly.image = img_msg
+
+        self.last_image = anomaly
+
+    def stop_callback(self, stop_msg: Stop):
+        anomaly = AnomalyMsg()
+        anomaly.header = stop_msg.header
+        anomaly.node_name = self.get_name()
+        anomaly.type = AnomalyMsg.TEXT
+
+        if stop_msg.stop:
+            anomaly.importance = AnomalyMsg.WARNING
+            anomaly.msg = "Stop signal received."
+
+            self.anomaly_pub.publish(anomaly)
+
+    def speed_callback(self, msg: Float32):
+        if abs(self.last_speed - msg.data) > 0.1:
+            self.last_speed = msg.data
+
+            anomaly = AnomalyMsg()
+
+            anomaly.header = Header()
+            anomaly.header.stamp = self.get_clock().now().to_msg()
+            anomaly.header.frame_id = "collision_avoidance_frame"
+
+            anomaly.node_name = self.get_name()
+            anomaly.importance = AnomalyMsg.INFO
+            anomaly.type = AnomalyMsg.TEXT
+            anomaly.msg = f"The speed of the cart is {msg.data}"
+
+            self.anomaly_pub.publish(anomaly)
+
+    def timer_callback(self):
+        if self.last_image: 
+            self.get_logger().info("Publishing image")
+
+
+            self.anomaly_pub.publish(self.last_image)
+            self.last_image = None
+        else:
+            self.get_logger().info("Issue with previous image")
+    
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = CollisionAvoidanceAADLog()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -175,6 +175,8 @@ class LocalPlanner(rclpy.node.Node):
         self.new_path = True
         self.log(f"Path received: {str(msg)}")
 
+        # self.anomaly_detected("New path received", AnomalyMsg.INFO)
+
     def create_path(self):
         """Creates a path for the cart with a set of local_points
         Adds 15 more points between the google points

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -29,7 +29,7 @@ from geometry_msgs.msg import (
 from visualization_msgs.msg import Marker
 import tf_transformations as tf
 import tf2_geometry_msgs  #  Import is needed, even though not used explicitly
-from anomaly_msg.msg import AnomalyMsg 
+from anomaly_msg.msg import AnomalyMsg
 
 
 
@@ -48,6 +48,8 @@ class LocalPlanner(rclpy.node.Node):
         self.tar_speed = self.METERS / self.SECONDS  # Target speed?
 
         self.cur_speed = 0  # Another estimate of speed used for eta calculations
+
+        self.anomaly_detection_enabled = True
 
         self.new_path = False
         self.path_valid = False
@@ -129,7 +131,7 @@ class LocalPlanner(rclpy.node.Node):
         self.eta_pub = self.create_publisher(UInt64, "/eta", 10)
 
         # Publish ETA progress percentage
-        self.eta_progress_pub = self.create_publisher(UInt64, "/eta_progress", 10)
+        self.eta_percentage_pub = self.create_publisher(UInt64, "/eta_percentage", 10)
 
         # Publish the projected turning angle and path
         self.projection_pub = self.create_publisher(Marker, "/projected_path", 10)
@@ -191,7 +193,7 @@ class LocalPlanner(rclpy.node.Node):
         self.eta_next_report_percent = 20
         self.log(f"Path received: {str(msg)}")
 
-        # self.anomaly_detected("New path received", AnomalyMsg.INFO)
+        # self.anomaly_logging("New path received", AnomalyMsg.INFO)
 
     def create_path(self):
         """Creates a path for the cart with a set of local_points
@@ -299,7 +301,7 @@ class LocalPlanner(rclpy.node.Node):
             else:
                 self.path_valid = False
                 self.log_header("It appears the cart is already at the destination")
-                self.anomaly_detected("Cart is already at destination", AnomalyMsg.WARNING)
+                self.anomaly_logging("Cart is already at destination", AnomalyMsg.WARNING)
 
         if self.current_state.is_navigating:
             # Continue to loop while we have not hit the target destination, and the path is still valid
@@ -357,13 +359,13 @@ class LocalPlanner(rclpy.node.Node):
                 # Let operator know why current path has stopped
                 if self.path_valid:
                     self.log("Reached Destination succesfully without interruption")
-                    self.anomaly_detected("Arrived", AnomalyMsg.INFO)
+                    self.anomaly_logging("Arrived", AnomalyMsg.INFO)
                     self.arrived_pub.publish(notify_server)
                 else:
                     self.log(
                         "Already at destination, or there may be no path to get to the destination or navigation was interrupted."
                     )
-                    self.anomaly_detected("Either already at destination or destination can't be reached", AnomalyMsg.WARNING)
+                    self.anomaly_logging("Either already at destination or destination can't be reached", AnomalyMsg.WARNING)
 
                 # Update the internal state of the vehicle
                 self.vehicle_state_pub.publish(self.current_state)
@@ -511,7 +513,7 @@ class LocalPlanner(rclpy.node.Node):
             self.eta_pub.publish(eta_msg)
 
             if not self.eta_initial_report_sent:
-                self.anomaly_detected(
+                self.anomaly_logging(
                     f"ETA: {eta_msg.data}s at 0% complete",
                     AnomalyMsg.INFO,
                 )
@@ -529,13 +531,13 @@ class LocalPlanner(rclpy.node.Node):
 
             progress_msg = UInt64()
             progress_msg.data = progress_percent
-            self.eta_progress_pub.publish(progress_msg)
+            self.eta_percentage_pub.publish(progress_msg)
 
             while (
                 progress_percent >= self.eta_next_report_percent
                 and self.eta_next_report_percent <= 100
             ):
-                self.anomaly_detected(
+                self.anomaly_logging(
                     f"ETA progress: {self.eta_next_report_percent}% complete, ETA: {eta_msg.data}s",
                     AnomalyMsg.INFO,
                 )
@@ -596,20 +598,15 @@ class LocalPlanner(rclpy.node.Node):
         # self.get_logger().info(f'{'#' * 20}\n{log}\n{'#' * 20}')
         self.log(log)
 
-    def publish_stop_nav_cmd(self):
-        """Sends a zero-velocity command to stop the cart immediately."""
-        stop_msg = VelAngle()
-        stop_msg.vel = 0.0
-        stop_msg.angle = 0.0
-        self.motion_pub.publish(stop_msg)
-
-    def anomaly_detected(self, message, severity):
+    def anomaly_logging(self, message, severity):
         """Helper function to publish an anomaly detection message to the anomaly logging topic.
 
         Args:
             message (str): A description of the detected anomaly.
             severity (str): The severity level of the anomaly (e.g., "info", "warning", "error").
         """
+        if not self.anomaly_detection_enabled:
+            return
         anomaly_msg = AnomalyMsg()
 
         anomaly_msg.header.stamp = self.get_clock().now().to_msg()

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -276,6 +276,7 @@ class LocalPlanner(rclpy.node.Node):
             else:
                 self.path_valid = False
                 self.log_header("It appears the cart is already at the destination")
+                # self.anomaly_detected("Cart is already at destination", AnomalyMsg.WARNING)
 
         if self.current_state.is_navigating:
             # Continue to loop while we have not hit the target destination, and the path is still valid
@@ -333,11 +334,13 @@ class LocalPlanner(rclpy.node.Node):
                 # Let operator know why current path has stopped
                 if self.path_valid:
                     self.log("Reached Destination succesfully without interruption")
+                    # self.anomaly_detected("Arrived", AnomalyMsg.INFO)
                     self.arrived_pub.publish(notify_server)
                 else:
                     self.log(
                         "Already at destination, or there may be no path to get to the destination or navigation was interrupted."
                     )
+                    # self.anomaly_detected("Either already at destination or destination can't be reached", AnomalyMsg.WARNING)
 
                 # Update the internal state of the vehicle
                 self.vehicle_state_pub.publish(self.current_state)
@@ -467,7 +470,7 @@ class LocalPlanner(rclpy.node.Node):
 
 
             # # Remaining time in seconds
-            remaining_time = distance_remaining / self.cur_speed
+            remaining_time = distance_remaining / self.tar_speed # use target speed to avoid incorrect eta during speed up
             eta_msg = UInt64()
 
             # # Calculate the ETA to the end

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -29,6 +29,7 @@ from geometry_msgs.msg import (
 from visualization_msgs.msg import Marker
 import tf_transformations as tf
 import tf2_geometry_msgs  #  Import is needed, even though not used explicitly
+from anomaly_msg.msg import AnomalyLog
 
 
 class LocalPlanner(rclpy.node.Node):
@@ -92,6 +93,10 @@ class LocalPlanner(rclpy.node.Node):
         # Share the current status of the vehicle's state
         self.vehicle_state_pub = self.create_publisher(
             VehicleState, "/vehicle_state", 10
+        )
+
+        self.anomaly_pub = self.create_publisher(
+            AnomalyLog, "/ai_anomaly_logging", 10
         )
 
         # Send out speed and steering requests to motor endpoint
@@ -175,7 +180,7 @@ class LocalPlanner(rclpy.node.Node):
         self.new_path = True
         self.log(f"Path received: {str(msg)}")
 
-        # self.anomaly_detected("New path received", AnomalyMsg.INFO)
+        self.anomaly_detected("info: New path received")
 
     def create_path(self):
         """Creates a path for the cart with a set of local_points
@@ -276,7 +281,7 @@ class LocalPlanner(rclpy.node.Node):
             else:
                 self.path_valid = False
                 self.log_header("It appears the cart is already at the destination")
-                # self.anomaly_detected("Cart is already at destination", AnomalyMsg.WARNING)
+                self.anomaly_detected("warning: Cart is already at destination")
 
         if self.current_state.is_navigating:
             # Continue to loop while we have not hit the target destination, and the path is still valid
@@ -334,13 +339,15 @@ class LocalPlanner(rclpy.node.Node):
                 # Let operator know why current path has stopped
                 if self.path_valid:
                     self.log("Reached Destination succesfully without interruption")
-                    # self.anomaly_detected("Arrived", AnomalyMsg.INFO)
+                    self.anomaly_detected("info: Arrived")
                     self.arrived_pub.publish(notify_server)
                 else:
                     self.log(
                         "Already at destination, or there may be no path to get to the destination or navigation was interrupted."
                     )
-                    # self.anomaly_detected("Either already at destination or destination can't be reached", AnomalyMsg.WARNING)
+                    self.anomaly_detected(
+                        "warning: Either already at destination or destination can't be reached"
+                    )
 
                 # Update the internal state of the vehicle
                 self.vehicle_state_pub.publish(self.current_state)
@@ -529,6 +536,18 @@ class LocalPlanner(rclpy.node.Node):
         # self.get_logger().info(f'{'#' * 20}\n{log}\n{'#' * 20}')
         self.log(log)
 
+    def anomaly_detected(self, description):
+        anomaly_msg = AnomalyLog()
+        anomaly_msg.stamp = self.get_clock().now().to_msg()
+        anomaly_msg.node_name = self.get_name()
+        anomaly_msg.source = "local_planner"
+        anomaly_msg.description = description
+        anomaly_msg.topic_name = "/ai_anomaly_logging"
+        anomaly_msg.data_type = "text"
+        anomaly_msg.data = []
+
+        self.anomaly_pub.publish(anomaly_msg)
+
 
 def create_pose_stamped(point):
     stamped = PoseStamped()
@@ -563,30 +582,6 @@ def create_marker(x, y, frame_id):
     marker.color.b = 0.0
 
     return marker
-
-# def anomaly_detected(self, message, severity):
-#     """Helper function to publish an anomaly detection message to the anomaly logging topic.
-
-#     Args:
-#         message (str): A description of the detected anomaly.
-#         severity (str): The severity level of the anomaly (e.g., "info", "warning", "error").
-#     """
-#     anomaly_msg = AnomalyMsg()
-
-#     # Header
-#     anomaly_msg.header.stamp = self.get_clock().now().to_msg()
-#     anomaly_msg.header.frame_id = "local_planner"
-
-#     # Required fields
-#     anomaly_msg.node_name = self.get_name()
-#     anomaly_msg.importance = severity
-#     anomaly_msg.type = AnomalyMsg.TEXT
-
-#     # Human-readable description of the anomaly
-#     anomaly_msg.msg= message
-    
-#     self.anomaly_pub.publish(anomaly_msg)
-
 
 def main():
     """The main method that actually handles spinning up the node."""

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -29,7 +29,8 @@ from geometry_msgs.msg import (
 from visualization_msgs.msg import Marker
 import tf_transformations as tf
 import tf2_geometry_msgs  #  Import is needed, even though not used explicitly
-from anomaly_msg.msg import AnomalyLog
+from anomaly_msg.msg import AnomalyMsg 
+
 
 
 class LocalPlanner(rclpy.node.Node):
@@ -54,7 +55,6 @@ class LocalPlanner(rclpy.node.Node):
         self.path_total_distance = 0.0
         self.eta_initial_report_sent = False
         self.eta_next_report_percent = 20
-        self.eta_ignore_first_progress_sample = True
 
         self.current_state = VehicleState()
         self.stop_requests = {}
@@ -99,9 +99,10 @@ class LocalPlanner(rclpy.node.Node):
             VehicleState, "/vehicle_state", 10
         )
 
-        self.anomaly_pub = self.create_publisher(
-            AnomalyLog, "/ai_anomaly_logging", 10
-        )
+        self.anomaly_pub = self.create_publisher(AnomalyMsg, 
+                                             '/ai_anomaly_logging',
+                                             10
+                                             )
 
         # Send out speed and steering requests to motor endpoint
         self.motion_pub = self.create_publisher(VelAngle, "/nav_cmd", 10)
@@ -188,10 +189,9 @@ class LocalPlanner(rclpy.node.Node):
         self.path_total_distance = 0.0
         self.eta_initial_report_sent = False
         self.eta_next_report_percent = 20
-        self.eta_ignore_first_progress_sample = True
         self.log(f"Path received: {str(msg)}")
 
-        self.anomaly_detected("info: New path received")
+        # self.anomaly_detected("New path received", AnomalyMsg.INFO)
 
     def create_path(self):
         """Creates a path for the cart with a set of local_points
@@ -299,7 +299,7 @@ class LocalPlanner(rclpy.node.Node):
             else:
                 self.path_valid = False
                 self.log_header("It appears the cart is already at the destination")
-                self.anomaly_detected("warning: Cart is already at destination")
+                self.anomaly_detected("Cart is already at destination", AnomalyMsg.WARNING)
 
         if self.current_state.is_navigating:
             # Continue to loop while we have not hit the target destination, and the path is still valid
@@ -357,15 +357,13 @@ class LocalPlanner(rclpy.node.Node):
                 # Let operator know why current path has stopped
                 if self.path_valid:
                     self.log("Reached Destination succesfully without interruption")
-                    self.anomaly_detected("info: Arrived")
+                    self.anomaly_detected("Arrived", AnomalyMsg.INFO)
                     self.arrived_pub.publish(notify_server)
                 else:
                     self.log(
                         "Already at destination, or there may be no path to get to the destination or navigation was interrupted."
                     )
-                    self.anomaly_detected(
-                        "warning: Either already at destination or destination can't be reached"
-                    )
+                    self.anomaly_detected("Either already at destination or destination can't be reached", AnomalyMsg.WARNING)
 
                 # Update the internal state of the vehicle
                 self.vehicle_state_pub.publish(self.current_state)
@@ -513,12 +511,11 @@ class LocalPlanner(rclpy.node.Node):
             self.eta_pub.publish(eta_msg)
 
             if not self.eta_initial_report_sent:
-                self.anomaly_detected(f"ETA: {eta_msg.data}s at 0% complete")
+                self.anomaly_detected(
+                    f"ETA: {eta_msg.data}s at 0% complete",
+                    AnomalyMsg.INFO,
+                )
                 self.eta_initial_report_sent = True
-
-            if self.eta_ignore_first_progress_sample:
-                self.eta_ignore_first_progress_sample = False
-                return
 
             if len(self.local_points) > 1:
                 current_index = self.local_points.index(current_node)
@@ -539,7 +536,11 @@ class LocalPlanner(rclpy.node.Node):
                 and self.eta_next_report_percent <= 100
             ):
                 self.anomaly_detected(
-                    f"ETA progress: {self.eta_next_report_percent}% complete"
+                    f"ETA progress: {self.eta_next_report_percent}% complete, ETA: {eta_msg.data}s",
+                    AnomalyMsg.INFO,
+                )
+                self.log(
+                    f"ETA progress published: {self.eta_next_report_percent}%"
                 )
                 self.eta_next_report_percent += 20
 
@@ -595,15 +596,28 @@ class LocalPlanner(rclpy.node.Node):
         # self.get_logger().info(f'{'#' * 20}\n{log}\n{'#' * 20}')
         self.log(log)
 
-    def anomaly_detected(self, description):
-        anomaly_msg = AnomalyLog()
-        anomaly_msg.stamp = self.get_clock().now().to_msg()
+    def publish_stop_nav_cmd(self):
+        """Sends a zero-velocity command to stop the cart immediately."""
+        stop_msg = VelAngle()
+        stop_msg.vel = 0.0
+        stop_msg.angle = 0.0
+        self.motion_pub.publish(stop_msg)
+
+    def anomaly_detected(self, message, severity):
+        """Helper function to publish an anomaly detection message to the anomaly logging topic.
+
+        Args:
+            message (str): A description of the detected anomaly.
+            severity (str): The severity level of the anomaly (e.g., "info", "warning", "error").
+        """
+        anomaly_msg = AnomalyMsg()
+
+        anomaly_msg.header.stamp = self.get_clock().now().to_msg()
+        anomaly_msg.header.frame_id = "local_planner"
         anomaly_msg.node_name = self.get_name()
-        anomaly_msg.source = "local_planner"
-        anomaly_msg.description = description
-        anomaly_msg.topic_name = "/ai_anomaly_logging"
-        anomaly_msg.data_type = "text"
-        anomaly_msg.data = []
+        anomaly_msg.importance = severity
+        anomaly_msg.type = AnomalyMsg.TEXT
+        anomaly_msg.msg = message
 
         self.anomaly_pub.publish(anomaly_msg)
 
@@ -642,6 +656,7 @@ def create_marker(x, y, frame_id):
 
     return marker
 
+
 def main():
     """The main method that actually handles spinning up the node."""
 
@@ -649,7 +664,6 @@ def main():
     node = LocalPlanner()
 
     rclpy.spin(node)
-
     node.destroy_node()
     rclpy.shutdown()
 

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -2,7 +2,7 @@
 """
 This is the ROS 2 node that handles the local planning for the JACART.
 
-Authors: Zane Metz, Lorenzo Ashurst, Zach Putz
+Authors: Zane Metz, Lorenzo Ashurst, Zach Putz, Hunter Fauntleroy
 """
 # Python based imports
 import math

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -51,6 +51,10 @@ class LocalPlanner(rclpy.node.Node):
         self.new_path = False
         self.path_valid = False
         self.local_points = []
+        self.path_total_distance = 0.0
+        self.eta_initial_report_sent = False
+        self.eta_next_report_percent = 20
+        self.eta_ignore_first_progress_sample = True
 
         self.current_state = VehicleState()
         self.stop_requests = {}
@@ -123,6 +127,9 @@ class LocalPlanner(rclpy.node.Node):
         # Publish the ETA
         self.eta_pub = self.create_publisher(UInt64, "/eta", 10)
 
+        # Publish ETA progress percentage
+        self.eta_progress_pub = self.create_publisher(UInt64, "/eta_progress", 10)
+
         # Publish the projected turning angle and path
         self.projection_pub = self.create_publisher(Marker, "/projected_path", 10)
 
@@ -178,6 +185,10 @@ class LocalPlanner(rclpy.node.Node):
 
         self.path_valid = False
         self.new_path = True
+        self.path_total_distance = 0.0
+        self.eta_initial_report_sent = False
+        self.eta_next_report_percent = 20
+        self.eta_ignore_first_progress_sample = True
         self.log(f"Path received: {str(msg)}")
 
         self.anomaly_detected("info: New path received")
@@ -271,6 +282,13 @@ class LocalPlanner(rclpy.node.Node):
                 self.target_ind = pure_pursuit.calc_target_index(
                     self.state, self.cx, self.cy, 0
                 )
+
+                if len(self.local_points) > 1:
+                    self.path_total_distance = self.calc_trip_dist(
+                        self.local_points, self.local_points[0]
+                    )
+                else:
+                    self.path_total_distance = 0.0
 
                 # Publish the ETA to the destination before we get started
                 self.calc_eta()
@@ -465,11 +483,17 @@ class LocalPlanner(rclpy.node.Node):
     def calc_eta(self):
         """Calculates the Estimated Time of Arrival to the destination"""
         # Attempt an update only while driving
-        if self.current_state.is_navigating:
+        if self.current_state.is_navigating and self.local_points:
+            if self.tar_speed <= 0:
+                return
+
             # Where are we at and how much further must we go
             current_node = self.get_closest_point(
                 self.cur_pose.position.x, self.cur_pose.position.y
             )
+
+            if current_node is None:
+                return
 
             # self.log("x: " + str(self.cur_pose.position.x) + "y: " + str(self.cur_pose.position.y))
 
@@ -488,6 +512,37 @@ class LocalPlanner(rclpy.node.Node):
             # eta_msg.data = 0
             self.eta_pub.publish(eta_msg)
 
+            if not self.eta_initial_report_sent:
+                self.anomaly_detected(f"ETA: {eta_msg.data}s at 0% complete")
+                self.eta_initial_report_sent = True
+
+            if self.eta_ignore_first_progress_sample:
+                self.eta_ignore_first_progress_sample = False
+                return
+
+            if len(self.local_points) > 1:
+                current_index = self.local_points.index(current_node)
+                progress_percent = int(
+                    round((current_index / (len(self.local_points) - 1)) * 100)
+                )
+            else:
+                progress_percent = 0
+
+            progress_percent = max(0, min(100, progress_percent))
+
+            progress_msg = UInt64()
+            progress_msg.data = progress_percent
+            self.eta_progress_pub.publish(progress_msg)
+
+            while (
+                progress_percent >= self.eta_next_report_percent
+                and self.eta_next_report_percent <= 100
+            ):
+                self.anomaly_detected(
+                    f"ETA progress: {self.eta_next_report_percent}% complete"
+                )
+                self.eta_next_report_percent += 20
+
     def calc_trip_dist(self, points_list, start):
         """Calculates the trip distance from the "start" Point to the end of the "points_list"
 
@@ -497,7 +552,11 @@ class LocalPlanner(rclpy.node.Node):
         """
         total_distance = 0
 
-        for i in range(self.local_points.index(start), len(points_list)):
+        start_index = self.local_points.index(start)
+        if start_index >= len(points_list) - 1:
+            return 0
+
+        for i in range(start_index + 1, len(points_list)):
             total_distance += self.calc_dist(
                 points_list[i].x,
                 points_list[i].y,

--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -559,6 +559,29 @@ def create_marker(x, y, frame_id):
 
     return marker
 
+# def anomaly_detected(self, message, severity):
+#     """Helper function to publish an anomaly detection message to the anomaly logging topic.
+
+#     Args:
+#         message (str): A description of the detected anomaly.
+#         severity (str): The severity level of the anomaly (e.g., "info", "warning", "error").
+#     """
+#     anomaly_msg = AnomalyMsg()
+
+#     # Header
+#     anomaly_msg.header.stamp = self.get_clock().now().to_msg()
+#     anomaly_msg.header.frame_id = "local_planner"
+
+#     # Required fields
+#     anomaly_msg.node_name = self.get_name()
+#     anomaly_msg.importance = severity
+#     anomaly_msg.type = AnomalyMsg.TEXT
+
+#     # Human-readable description of the anomaly
+#     anomaly_msg.msg= message
+    
+#     self.anomaly_pub.publish(anomaly_msg)
+
 
 def main():
     """The main method that actually handles spinning up the node."""

--- a/navigation/setup.py
+++ b/navigation/setup.py
@@ -45,6 +45,7 @@ setup(
             "pose_bridge = navigation.pose_bridge:main",
             "zed_object_to_obstacle = navigation.zed_object_to_obstacle:main",
             "lidar_object_to_obstacle = navigation.lidar_object_to_obstacle:main",
+            "collision_avoidance_aad_log = navigation.collision_avoidance_aad_log:main",
         ],
     },
 )


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #103 #112 

Closes ticket 62 in AAD. 

There should be more for management and UI; however, I could not find the tickets. 

---

# Summary

This PR introduces the AAD logging logic, specifically for motor endpoints, UI, localization (eta), and collision avoidance. Additionally, we just added changes to the launch files so that AAD logging can be toggled off. This is named 'enable_aad'.

---

# Testing Summary

Since the only chances should be logging, we tested to make sure that messages are being received. This means we tested each of the following:
- ETA: We started the cart autonomously and received eta messages. 
- Motor endpoints: Motor endpoints will only log if there is an issue. To test, we did not plug in the cords and got heartbeat error messages coming through. 
- Collision Avoidance: We were able to receive images on the ai_anomaly_logging topic. There was some issues with the zed camera on madison though. 
- UI: We tested the 'James stop' command and received a message on the ai_anomaly_logging topic. 
- Launch files: We ran the autonomous launcher and the corrected messages were logged. Then, we turned off 'enable_aad' and did not see messages. 
---

# Testing Instructions

ETA:
1. Launch the cart
2. Localize and set a goal
3. Echo the 'ai_anomaly_logging' topic. The eta data should be showing up. 

UI:
1. Launch the cart
2. Interact with the cart through the UI, whether that be audio or clicking. 
3. Echo the 'ai_anomaly_logging' topic. A message describing the UI interaction should be showing up. 

Motor endpoint:
1. Launch the cart
2. Echo the 'ai_anomaly_logging' topic. Messages logging the lack of heartbeats should be coming through. 
Note: Nothing with show up if everything is behaving as expected. If you are not seeing messages, make sure you are not connected to the cart. 

Collision Avoidance:
1. Make sure the cameras are connected with the correct serial numbers. 
2. Launch the cart
4. Start tmux.
5. Run 'ros2 run navigation collision_avoidance_aad_log'. 
6. In another window, Echo the 'ai_anomaly_logging' topic. Messages logging image data should be coming through. 
Notes: If there is nothing showing up ('aka Issue with Image' is logging in the node), check the camera topic: /zed_front/zed_node_0/rgb/rect/image. It is normal for it to say issue with image at the start of the run, but if it continues it might not be getting any image data. 

Launch file:
1. Run ./dev-run-backend.sh
2. Run source install/setup.bash
3. Start tmux
4. Run ros2 launch cart_launch autonomous_launcher.launch.py.
6. Switch windows and run 'ros2 node list | grep collision_avoidance'. You should see the CA logging node. 
7. In the same window, run 'ros2 node list | grep motor_endpoint'. You should see that motor endpoint appears.
8. Exit the windows and run docker teardown. 
9. Run ./dev-run-backend.sh
10. Run source install/setup.bash
11. Start tmux. 
12. Run ros2 launch cart_launch autonomous_launcher.launch.py enable_aad:=false
13. Switch windows and run 'ros2 node list | grep collision_avoidance'. You should NOT see the CA logging node. 
7. In the same window, run 'ros2 node list | grep motor_endpoint'. You should see that motor endpoint appears.
8. Exit the windows and run docker teardown. 

---

# Success Metrics (From Issue)

- [x] Metric 1: ETA data received
- [x] Metric 2: Collision avoidance data received
- [x] Metric 3: UI data received
- [x] Metric 4: Motor endpoint data received.
- [x] Metric 5: AAD logging can be turned on and off. 

---

# Integration Impact

Yes, this will allow us to move forward with anomaly detection. 