### PR TITLE
fix premature success declaration for simulator

### DIFF
--- a/navigation/navigation/local_planner.py
+++ b/navigation/navigation/local_planner.py
@@ -40,6 +40,7 @@ class LocalPlanner(rclpy.node.Node):
         super().__init__("local_planner")
 
         self.declare_parameter("cruise_speed", 30.0)
+        self.declare_parameter("goal_tolerance", 1.0)
 
         # driving constants THIS USED TO BE 10 and 3.6 respectively
         self.METERS = (
@@ -52,6 +53,9 @@ class LocalPlanner(rclpy.node.Node):
         self.tar_speed = self.METERS / self.SECONDS  # Target speed?
 
         self.cur_speed = 0  # Another estimate of speed used for eta calculations
+        self.goal_tolerance = (
+            self.get_parameter("goal_tolerance").get_parameter_value().double_value
+        )
 
         self.anomaly_detection_enabled = True
 
@@ -308,8 +312,10 @@ class LocalPlanner(rclpy.node.Node):
                 self.anomaly_logging("Cart is already at destination", AnomalyMsg.WARNING)
 
         if self.current_state.is_navigating:
+            goal_reached = self.reached_goal()
+
             # Continue to loop while we have not hit the target destination, and the path is still valid
-            if self.last_index > self.target_ind and self.path_valid:
+            if self.path_valid and not goal_reached:
 
                 # Uneeded unless testing (floods the terminal with messages when active)
                 # self.get_logger().info(
@@ -378,6 +384,20 @@ class LocalPlanner(rclpy.node.Node):
                 plan_msg.angle = 0.0
 
                 self.motion_pub.publish(plan_msg)
+
+    def reached_goal(self):
+        if not self.path_valid or not hasattr(self, "cx") or not self.cx:
+            return False
+
+        return (
+            self.calc_dist(
+                self.cur_pose.position.x,
+                self.cur_pose.position.y,
+                self.cx[self.last_index],
+                self.cy[self.last_index],
+            )
+            <= self.goal_tolerance
+        )
 
     def update(self, state, a, delta):
         """Updates the carts position by a given state and delta"""

--- a/navigation/navigation/simulated_motor_endpoint.py
+++ b/navigation/navigation/simulated_motor_endpoint.py
@@ -13,7 +13,7 @@ import rclpy
 from tf_transformations import quaternion_from_euler, euler_from_quaternion
 import tf2_geometry_msgs  #  Import is needed, even though not used explicitly
 from motor_control_interface.msg import VelAngle
-from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped
+from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped, TwistStamped
 from std_msgs.msg import Float32
 
 
@@ -43,6 +43,7 @@ class SimulatedMotor(rclpy.node.Node):
 
         self.pose_pub = self.create_publisher(PoseStamped, "/limited_pose", 10)
         self.vel_pub = self.create_publisher(Float32, "/estimated_vel_mps", 10)
+        self.twist_pub = self.create_publisher(TwistStamped, "/estimate_twist", 10)
         self.local_pose_pub = self.create_publisher(
             PoseWithCovarianceStamped, "/pcl_pose", 10
         )
@@ -120,6 +121,11 @@ class SimulatedMotor(rclpy.node.Node):
         vel = Float32()
         vel.data = self.vel
         self.vel_pub.publish(vel)
+
+        twist = TwistStamped()
+        twist.header = pose.header
+        twist.twist.linear.x = self.vel
+        self.twist_pub.publish(twist)
 
     def calculate_endpoint(self):
         """The endpoint for processing and sending instructions to the arduino controller."""


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #<issue_number>

---

# Summary

Small simulator fix

The target point kept on becoming decentralized from the cart's position, leading to the cart stopping before reaching the end position. This change ensures that the cart must be close to the goal position before declaring success.

---

# Testing Summary

The cart behaves slightly differently, the cart will now only stop when it reaches the goal point. Previously, it would stop before reaching the goal point.

---

# Testing Instructions
1. Run the cart simulator
2. publish a goal point
3. Observe to see if the cart successfully stops at the end point
4. Repeat steps 2-3 10 times to confirm functionality.


---

# Success Metrics (From Issue)



---

# Integration Impact

