### PR TITLE
Added auto-zed configuration based on ROS domain

### DIFF
--- a/cart_control/cart_launch/autonomous_launch/cart_config_resolver.py
+++ b/cart_control/cart_launch/autonomous_launch/cart_config_resolver.py
@@ -1,0 +1,45 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+
+_DOMAIN_TO_CART = {
+    0: "james",
+    1: "madison",
+}
+
+
+def _cart_config_path(cart_name: str) -> str:
+    return os.path.join(
+        get_package_share_directory("cart_launch"),
+        "config",
+        f"cart_{cart_name}.yaml",
+    )
+
+
+def resolve_cart_config_path(explicit_path: str = "") -> str:
+    """Return an explicit cart config path or infer one from ROS_DOMAIN_ID."""
+    if explicit_path:
+        return explicit_path
+
+    domain_raw = os.environ.get("ROS_DOMAIN_ID", "0").strip()
+    try:
+        domain_id = int(domain_raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"ROS_DOMAIN_ID must be an integer, got '{domain_raw}'"
+        ) from exc
+
+    cart_name = _DOMAIN_TO_CART.get(domain_id)
+    if cart_name is None:
+        raise RuntimeError(
+            "No cart config mapping is defined for ROS_DOMAIN_ID="
+            f"{domain_id}. Supported mappings: 0 -> james, 1 -> madison."
+        )
+
+    return _cart_config_path(cart_name)
+
+
+def default_cart_config_path() -> str:
+    """Return the default cart config path inferred from ROS_DOMAIN_ID."""
+    return resolve_cart_config_path()

--- a/cart_control/cart_launch/launch/autonomous_launcher.launch.py
+++ b/cart_control/cart_launch/launch/autonomous_launcher.launch.py
@@ -4,6 +4,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from autonomous_launch.cart_config_resolver import default_cart_config_path
 from ament_index_python.packages import get_package_share_directory 
 import os
 import launch_ros
@@ -23,10 +24,11 @@ def generate_launch_description():
     )
     declare_cart_config_path = DeclareLaunchArgument(
         "cart_config_path",
-        default_value=os.path.join(
-            get_package_share_directory("cart_launch"), "config", "cart_james.yaml"
+        default_value=default_cart_config_path(),
+        description=(
+            "Path to cart-specific YAML config. Defaults to the config mapped "
+            "from ROS_DOMAIN_ID (0 -> James, 1 -> Madison)."
         ),
-        description="Path to cart-specific YAML config (must contain zed_front_serial and zed_rear_serial)",
     )
     declare_enable_aad = DeclareLaunchArgument(
         "enable_aad",

--- a/cart_control/cart_launch/package.xml
+++ b/cart_control/cart_launch/package.xml
@@ -8,6 +8,7 @@
   <license>Apache 2.0</license> 
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/cart_control/localization_launch/launch/cameras.launch.py
+++ b/cart_control/localization_launch/launch/cameras.launch.py
@@ -4,6 +4,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.utilities import perform_substitutions
 from launch_ros.actions import Node
+from autonomous_launch.cart_config_resolver import resolve_cart_config_path
 from ament_index_python.packages import get_package_share_directory
 import os
 import yaml
@@ -28,9 +29,9 @@ def generate_launch_description():
     )
 
     def _include_zed_multi_camera(context, *args, **kwargs):
-        cfg_path = perform_substitutions(context, [cart_config_path]).strip()
-        if not cfg_path:
-            raise RuntimeError("Required launch argument 'cart_config_path' is empty")
+        cfg_path = resolve_cart_config_path(
+            perform_substitutions(context, [cart_config_path]).strip()
+        )
 
         with open(cfg_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
@@ -93,7 +94,11 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 "cart_config_path",
-                description="Path to cart-specific YAML config (must contain zed_front_serial and zed_rear_serial)",
+                default_value="",
+                description=(
+                    "Optional path to cart-specific YAML config. When omitted, "
+                    "the config is inferred from ROS_DOMAIN_ID."
+                ),
             ),
             zed_multi_camera_launch,
             multi_link_tf,

--- a/cart_control/localization_launch/launch/localization_full_launcher.launch.py
+++ b/cart_control/localization_launch/launch/localization_full_launcher.launch.py
@@ -18,6 +18,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+from autonomous_launch.cart_config_resolver import default_cart_config_path
 from ament_index_python.packages import get_package_share_directory
 import os
 import yaml
@@ -130,10 +131,10 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "cart_config_path",
-                default_value="",
+                default_value=default_cart_config_path(),
                 description=(
-                    "Path to cart-specific YAML config (must contain zed_front_serial "
-                    "and zed_rear_serial). Required when not using a bag file."
+                    "Path to cart-specific YAML config. Defaults to the config mapped "
+                    "from ROS_DOMAIN_ID (0 -> James, 1 -> Madison)."
                 ),
             ),
             DeclareLaunchArgument(

--- a/cart_control/localization_launch/package.xml
+++ b/cart_control/localization_launch/package.xml
@@ -9,6 +9,7 @@
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>cart_launch</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #<issue_number>

---

# Summary

Ties the used config file for the ZED cameras to the ROS domain, which should be 0 for James and 1 for Madison. This way, there is a set ID for each cart, which enables long-term configuration if we were to have another cart.

---

# Testing Summary

James successfully only receives lidar and zed data when on ROS domain 0, and Madison successfully only receives lidar and zed data when on ROS domain 1.

---

# Testing Instructions

1. Plug into Madison
2. Run the container specifying ROS domain 1 using: ./dev-run-backend madison
3. Run the autonomous launcher via: ros2 launch cart_launch autonomous_launcher.launch.py
4. Confirm that rviz is displaying Madison's ZED camera data and lidar data
5. Relaunch the container specifying ROS domain 0 using: ./dev-run-backend
6. Run the autonomous launcher via ros2 launch cart_launch autonomous_launcher.launch.py
7. Have someone launch James's autonomous launcher via: ros2 launch cart_launch autonomous_launcher.launch.py
8. Confirm that rviz is receiving James's lidar data (but not ZED)
9. Unplug from Madison
10. Plug into James
11. Run the container specifying ROS domain 0 using: ./dev-run-backend
12. Run the autonomous launcher via: ros2 launch cart_launch autonomous_launcher.launch.py
13. Confirm that rviz is displaying James's ZED camera data and lidar data
14. Relaunch the container specifying ROS domain 1 using: ./dev-run-backend madison
15. Run the autonomous launcher via ros2 launch cart_launch autonomous_launcher.launch.py
16. Have someone launch Madison's autonomous launcher via: ros2 launch cart_launch autonomous_launcher.launch.py
17. Confirm that rviz is receiving Madison's lidar data (but not ZED)

# Success Metrics (From Issue)

1. When on ROS domain 0, rviz should only receive James's lidar data, and if plugged into James, should also receive James's ZED camera data.
2. When on ROS domain 1, rviz should only receive Madison's lidar data, and if plugged into Madison, should also receive Madison's ZED camera data.

---

# Integration Impact

This helps cart testers work in parallel by preventing the data produced by James to be sent to Madison and vice versa.




